### PR TITLE
Use `int` for nwg-bar icon size

### DIFF
--- a/nwg_shell_config/ui_components.py
+++ b/nwg_shell_config/ui_components.py
@@ -1017,7 +1017,7 @@ def bar_tab(preset, preset_name):
 
     sb_icon_size = Gtk.SpinButton.new_with_range(8, 256, 1)
     sb_icon_size.set_value(preset["exit-icon-size"])
-    sb_icon_size.connect("value-changed", set_from_spinbutton, preset, "exit-icon-size", 1)
+    sb_icon_size.connect("value-changed", set_int_from_spinbutton, preset, "exit-icon-size")
     sb_icon_size.set_tooltip_text("Item icon size.")
     grid.attach(sb_icon_size, 1, 3, 1, 1)
 


### PR DESCRIPTION
Currently nwg-shell-config sets icon size to float which causes the following issue
```
❯ nwg-bar -p center -f -a middle -i 50.0 -s preset-0.css
invalid value "50.0" for flag -i: parse error
Usage of nwg-bar:
  -a string
        Alignment in full width/height: "start" or "end" (default "middle")
  -f    take Full screen width/height
  -g string
        GTK theme name
  -i int
        Icon size (default 48)
  -mb int
        Margin Bottom
  -ml int
        Margin Left
  -mr int
        Margin Right
  -mt int
        Margin Top
  -o string
        name of Output to display the bar on
  -p string
        Position: "bottom", "top", "left" or "right" (default "center")
  -s string
        csS file name (default "style.css")
  -t string
        Template file name (default "bar.json")
  -v    display Version information
  -x    open on top layer witch eXclusive zone
```