### PR TITLE
fix custom update command not working

### DIFF
--- a/nwg_shell_config/update_indicator.py
+++ b/nwg_shell_config/update_indicator.py
@@ -195,7 +195,10 @@ class Indicator(object):
         # You just need to provide your own `nwg-system-update` script somewhere on $PATH.
         # IMPORTANT: the presence of this script will also determine if to display corresponding
         # options in the config utility.
-        subprocess.call("exec foot nwg-system-update '{}'".format(voc["press-enter-to-exit"]), shell=True)
+        if settings["update-command"] == "nwg-system-update":
+            subprocess.call("exec foot nwg-system-update '{}'".format(voc["press-enter-to-exit"]), shell=True)
+        else:
+            subprocess.call("exec {}".format(settings["update-command"]), shell=True)
 
         self.check_updates()
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-shell-config',
-    version='0.4.11',
+    version='0.4.12',
     description='nwg-shell configuration utility',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
In 0.4.11 I added a field to enter users own command to perform system updates, but forgot to make use of it. This is to fix the mistake.