### PR TITLE
multi-lang support

### DIFF
--- a/nwg_shell_config/translate.py
+++ b/nwg_shell_config/translate.py
@@ -232,7 +232,7 @@ def load_dict_and_build_window(combo, load_voc_user=True):
         global voc_en_us
         voc_en_us = load_json(os.path.join(langs_dir, "en_US.json"))
         if voc_en_us:
-            print("Default dict:\ten_US.json, {} keys".format(len(voc_en_us)))
+            print("Default dict: en_US.json, {} keys".format(len(voc_en_us)))
         else:
             eprint("Couldn't load basic dictionary, exiting.")
             sys.exit(1)
@@ -248,7 +248,7 @@ def load_dict_and_build_window(combo, load_voc_user=True):
             global voc_user
             voc_user = load_json(os.path.join(langs_dir, "{}.json".format(user_locale)))
             if voc_user:
-                print("User dict:\t\t{}.json, {} keys".format(user_locale, len(voc_user)))
+                print("User dict: {}.json, {} keys".format(user_locale, len(voc_user)))
             else:
                 voc_user = {}
                 print("User lang '{}' does not yet exist, creating empty dictionary.".format(user_locale))

--- a/nwg_shell_config/translate.py
+++ b/nwg_shell_config/translate.py
@@ -202,7 +202,7 @@ def load_dictionary(combo):
     name = importlib.util.find_spec(combo.get_active_id()).origin
     parts = name.split("/")
     langs_dir = os.path.join("/".join(parts[:-1]), "langs")
-    print("langs_dir:", langs_dir)
+    print("\nlangs_dir:", langs_dir)
     print(load_json(os.path.join(langs_dir, "en_US.json")))
 
     global existing_langs

--- a/nwg_shell_config/translate.py
+++ b/nwg_shell_config/translate.py
@@ -203,7 +203,7 @@ def load_dictionary(combo):
     parts = name.split("/")
     langs_dir = os.path.join("/".join(parts[:-1]), "langs")
     print("\nlangs_dir:", langs_dir)
-    print(load_json(os.path.join(langs_dir, "en_US.json")))
+    # print(load_json(os.path.join(langs_dir, "en_US.json")))
 
     global existing_langs
     existing_langs = []

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-shell-config',
-    version='0.8.0',
+    version='0.4.17',
     description='nwg-shell configuration utility',
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-shell-config',
-    version='0.4.17',
+    version='0.8.0',
     description='nwg-shell configuration utility',
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-shell-config',
-    version='0.4.16',
+    version='0.4.17',
     description='nwg-shell configuration utility',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
The nwg-shell-translate utility from now on supports multiple nwg-shell components. For now just nwg-shell-config and nwg-panel are ready for this. Next in line are nwg-look, nwg-displays and Azote, but it's going to take some time.

Please find this update a bit experimental, as it was only tested by me. Report bugs if spotted.

I'll be grateful for submitting new translations, especially to nwg-panel.