### PR TITLE
add `-s | --save` argument

### DIFF
--- a/nwg_shell_config/main_hyprland.py
+++ b/nwg_shell_config/main_hyprland.py
@@ -1214,6 +1214,7 @@ def load_settings_save_includes():
     data_dir = get_data_dir()
     load_presets()
     load_settings()
+    save_includes()
     sys.exit(0)
 
 

--- a/nwg_shell_config/main_hyprland.py
+++ b/nwg_shell_config/main_hyprland.py
@@ -13,6 +13,7 @@ import argparse
 import os.path
 import signal
 import subprocess
+import sys
 import time
 
 from nwg_shell_config.tools import *
@@ -1208,6 +1209,14 @@ def load_vocabulary():
                     voc[key] = loc[key]
 
 
+def load_settings_save_includes():
+    global data_dir
+    data_dir = get_data_dir()
+    load_presets()
+    load_settings()
+    sys.exit(0)
+
+
 def restore_backup(b_path, voc):
     if b_path.startswith("~/"):
         b_path = os.path.join(os.getenv("HOME"), b_path[2:])
@@ -1234,8 +1243,16 @@ def main():
                         default="",
                         help="restore all configs from a backup file (given path)")
 
+    parser.add_argument("-s",
+                        "--save",
+                        action="store_true",
+                        help="load settings & Save includes (for use w/ external scripts ")
+
     parser.parse_args()
     args = parser.parse_args()
+
+    if args.save:
+        load_settings_save_includes()
 
     GLib.set_prgname('nwg-shell-config')
 

--- a/nwg_shell_config/main_hyprland.py
+++ b/nwg_shell_config/main_hyprland.py
@@ -1214,6 +1214,7 @@ def load_settings_save_includes():
     data_dir = get_data_dir()
     load_presets()
     load_settings()
+    print("Saving includes")
     save_includes()
     sys.exit(0)
 

--- a/nwg_shell_config/main_hyprland.py
+++ b/nwg_shell_config/main_hyprland.py
@@ -882,7 +882,9 @@ def save_includes():
 
         includes.append('}')
 
-    save_list_to_text_file(includes, os.path.join(config_home, "hypr/includes.conf"))
+    p = os.path.join(config_home, "hypr/includes.conf")
+    print("Saving includes to {}".format(p))
+    save_list_to_text_file(includes, p)
 
     reload()
 
@@ -1214,7 +1216,6 @@ def load_settings_save_includes():
     data_dir = get_data_dir()
     load_presets()
     load_settings()
-    print("Saving includes")
     save_includes()
     sys.exit(0)
 

--- a/nwg_shell_config/main_hyprland.py
+++ b/nwg_shell_config/main_hyprland.py
@@ -1249,7 +1249,7 @@ def main():
     parser.add_argument("-s",
                         "--save",
                         action="store_true",
-                        help="load settings & Save includes (for use w/ external scripts ")
+                        help="load settings & Save includes (for use w/ external scripts)")
 
     parser.parse_args()
     args = parser.parse_args()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-shell-config',
-    version='0.5.6',
+    version='0.5.7',
     description='nwg-shell configuration utility',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Added  `-s | --save` argument. If set, the program will read current settings, export the `~/.config/hypr/includes.conf` file and die. This is for use with external scripts. See: https://www.reddit.com/r/nwg_shell/comments/14by0by/request_keyboard_layout_switching/