### PR TITLE
support dwindle:smart_split

### DIFF
--- a/nwg_shell_config/langs/en_US.json
+++ b/nwg_shell_config/langs/en_US.json
@@ -309,6 +309,8 @@
   "show-on-startup-tooltip": "Uncheck to avoid running this window on startup",
   "sleep-command": "Sleep command",
   "sleep-timeout-tooltip": "Sleep timeout in seconds.\nMust be longer than Lock screen timeout.",
+  "smart-split": "Smart split",
+  "smart-split-tooltip": "Allows a more precise control over the window split direction based on the cursor’s position. The window is conceptually divided into four triangles, and cursor’s triangle determines the split direction. Turns on preserve_split.",
   "special-scale-factor": "Special scale factor",
   "special-scale-factor-tooltip": "0 - 1 -> specifies the scale factor of windows on the special workspace",
   "split-width-multiplier": "Split width multiplier",

--- a/nwg_shell_config/langs/pl_PL.json
+++ b/nwg_shell_config/langs/pl_PL.json
@@ -309,6 +309,8 @@
   "show-on-startup-tooltip": "Odznacz by nie uruchamiać tego okna podczas startu systemu.",
   "sleep-command": "Komenda uśpienia",
   "sleep-timeout-tooltip": "Opóźnienie uśpienia w sekundach.\nMusi być dłuższe niż opóźnienie blokady.",
+  "smart-split": "Inteligentny podział",
+  "smart-split-tooltip": "Włącza precyzyjną kontrolę nad podziałem okna na podstawie pozycji kursora. Okno jest koncepcyjnie podzielone na 3 trójkąty i ten, w którym znajduje się kursor określa kierunek podziału. Włącza 'Zachowaj podział'.",
   "special-scale-factor": "Specjalny wsp. podziału",
   "special-scale-factor-tooltip": "0 - 1 -> określa współczynnik podziału okien w specjalnym obszarze roboczym",
   "split-width-multiplier": "Mnożnik szerokości podziału",

--- a/nwg_shell_config/main_hyprland.py
+++ b/nwg_shell_config/main_hyprland.py
@@ -793,6 +793,7 @@ def save_includes():
         includes.append('    pseudotile = {}'.format(bool2lower(settings["dwindle-pseudotile"])))
         includes.append('    force_split = {}'.format(settings["dwindle-force_split"]))
         includes.append('    preserve_split = {}'.format(bool2lower(settings["dwindle-preserve_split"])))
+        includes.append('    smart_split = {}'.format(bool2lower(settings["dwindle-smart_split"])))
         includes.append('    special_scale_factor = {}'.format(settings["dwindle-special_scale_factor"]))
         includes.append('    split_width_multiplier = {}'.format(settings["dwindle-split_width_multiplier"]))
         includes.append('    no_gaps_when_only = {}'.format(bool2lower(settings["dwindle-no_gaps_when_only"])))

--- a/nwg_shell_config/ui_components.py
+++ b/nwg_shell_config/ui_components.py
@@ -1126,6 +1126,13 @@ def h_dwindle_tab(settings, voc):
     sb_dsr.connect("value-changed", set_from_spinbutton, settings, "dwindle-default_split_ratio", 3)
     grid.attach(sb_dsr, 1, 4, 1, 1)
 
+    cb_smart_split = Gtk.CheckButton.new_with_label(voc["smart-split"])
+    cb_smart_split.set_property("halign", Gtk.Align.START)
+    cb_smart_split.set_tooltip_text(voc["smart-split-tooltip"])
+    cb_smart_split.set_active(settings["dwindle-smart_split"])
+    cb_smart_split.connect("toggled", set_from_checkbutton, settings, "dwindle-smart_split")
+    grid.attach(cb_smart_split, 2, 4, 1, 1)
+
     frame.show_all()
 
     return frame

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-shell-config',
-    version='0.5.9',
+    version='0.5.10',
     description='nwg-shell configuration utility',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
smart_split allows a more precise control over the window split direction based on the cursor’s position. The window is conceptually divided into four triangles, and cursor’s triangle determines the split direction. This feature also turns on preserve_split. New in version 0.27.0.