### PR TITLE
Fix update indicator not working if baph is not installed

### DIFF
--- a/nwg_shell_config/update_indicator.py
+++ b/nwg_shell_config/update_indicator.py
@@ -279,7 +279,7 @@ def main():
         eprint("nwg-update-indicator running on '{}'".format(distro))
 
     if distro == "arch":
-        if not is_command("baph"):
+        if not is_command("baph") and not is_command("yay"):
             eprint("No supported AUR helper found, terminating")
             sys.exit(1)
 


### PR DESCRIPTION
Tried to change from using baph to yay on my Arch config, but update indicator doesn't work if baph is not installed. The following commit fixes it.