### PR TITLE
Fix Red Screen of Death on Hyprland

### DIFF
--- a/nwg_shell_config/locker.py
+++ b/nwg_shell_config/locker.py
@@ -10,13 +10,6 @@ import signal
 import sys
 import urllib.request
 
-import gi
-
-gi.require_version('Gtk', '3.0')
-gi.require_version('Gdk', '3.0')
-gi.require_version('GdkPixbuf', '2.0')
-gi.require_version('GtkLayerShell', '0.1')
-
 from nwg_shell_config.tools import get_data_dir, temp_dir, load_json, load_text_file, save_string, gtklock_module_path, \
     playerctl_metadata, eprint
 
@@ -91,16 +84,6 @@ def launch(button, cmd):
     subprocess.Popen('exec {}'.format(cmd), shell=True)
 
 
-def terminate_old_instance_if_any():
-    try:
-        old_pid = int(load_text_file(os.path.join(tmp_dir, "nwg-lock-pid")))
-        if old_pid != pid:
-            os.kill(old_pid, 15)
-    except:
-        pass
-    save_string(str(pid), os.path.join(tmp_dir, "nwg-lock-pid"))
-
-
 def set_remote_wallpaper():
     url = "https://source.unsplash.com/{}x{}/?{}".format(settings["unsplash-width"], settings["unsplash-height"],
                                                          ",".join(settings["unsplash-keywords"]))
@@ -135,8 +118,12 @@ def set_local_wallpaper():
     if len(paths) > 0:
         p = paths[random.randrange(len(paths))]
         if settings["lockscreen-locker"] == "swaylock":
-            subprocess.call("pkill -f swaylock", shell=True)
-            subprocess.Popen('swaylock -i {} ; kill -n 15 {}'.format(p, pid), shell=True)
+            # subprocess.call("pkill -f swaylock", shell=True)
+            # subprocess.Popen('swaylock -i {} ; kill -n 15 {}'.format(p, pid), shell=True)
+            subprocess.Popen('swaylock -i {}'.format(p), shell=True)
+            # subprocess.run(['swaylock', '-i', f'{p}'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            # sys.exit(0)
+
         elif settings["lockscreen-locker"] == "gtklock":
             subprocess.call("pkill -f gtklock", shell=True)
 

--- a/nwg_shell_config/locker.py
+++ b/nwg_shell_config/locker.py
@@ -74,16 +74,6 @@ preset_defaults = {
 }
 
 
-def signal_handler(sig, frame):
-    desc = {2: "SIGINT", 15: "SIGTERM", 10: "SIGUSR1"}
-    if sig == 2 or sig == 15:
-        print("Terminated with {}".format(desc[sig]))
-
-
-def launch(button, cmd):
-    subprocess.Popen('exec {}'.format(cmd), shell=True)
-
-
 def set_remote_wallpaper():
     url = "https://source.unsplash.com/{}x{}/?{}".format(settings["unsplash-width"], settings["unsplash-height"],
                                                          ",".join(settings["unsplash-keywords"]))
@@ -119,26 +109,19 @@ def set_local_wallpaper():
         p = paths[random.randrange(len(paths))]
         if settings["lockscreen-locker"] == "swaylock":
             subprocess.Popen('swaylock -i {}'.format(p), shell=True)
-            # just for clarity ;)
-            sys.exit(0)
 
         elif settings["lockscreen-locker"] == "gtklock":
-            subprocess.call("pkill -f gtklock", shell=True)
-
             eprint(
-                '{} -S -H -T {} -b {} ; kill -n 15 {}'.format(gtklock_command(), settings["gtklock-idle-timeout"], p,
-                                                               pid))
+                '{} -S -H -T {} -b {}'.format(gtklock_command(), settings["gtklock-idle-timeout"], p))
             subprocess.Popen(
-                '{} -S -H -T {} -b {} ; kill -n 15 {}'.format(gtklock_command(), settings["gtklock-idle-timeout"],
-                                                               p, pid), shell=True)
+                '{} -S -H -T {} -b {}'.format(gtklock_command(), settings["gtklock-idle-timeout"], p), shell=True)
     else:
         print("No image paths found")
 
         if settings["lockscreen-locker"] == "swaylock":
-            subprocess.call("pkill -f swaylock", shell=True)
             subprocess.Popen('exec swaylock -f', shell=True)
+
         elif settings["lockscreen-locker"] == "gtklock":
-            subprocess.call("pkill -f gtklock", shell=True)
             subprocess.Popen('exec gtklock -d', shell=True)
 
     sys.exit(0)
@@ -236,13 +219,8 @@ def main():
         if key not in preset:
             preset[key] = preset_defaults[key]
 
-    catchable_sigs = set(signal.Signals) - {signal.SIGKILL, signal.SIGSTOP}
-    for sig in catchable_sigs:
-        signal.signal(sig, signal_handler)
-
     if settings["lockscreen-custom-cmd"]:
         subprocess.Popen('exec {}'.format(settings["lockscreen-custom-cmd"]), shell=True)
-
         sys.exit(0)
 
     if settings["lockscreen-background-source"] == "unsplash":

--- a/nwg_shell_config/locker.py
+++ b/nwg_shell_config/locker.py
@@ -118,11 +118,9 @@ def set_local_wallpaper():
     if len(paths) > 0:
         p = paths[random.randrange(len(paths))]
         if settings["lockscreen-locker"] == "swaylock":
-            # subprocess.call("pkill -f swaylock", shell=True)
-            # subprocess.Popen('swaylock -i {} ; kill -n 15 {}'.format(p, pid), shell=True)
             subprocess.Popen('swaylock -i {}'.format(p), shell=True)
-            # subprocess.run(['swaylock', '-i', f'{p}'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            # sys.exit(0)
+            # just for clarity ;)
+            sys.exit(0)
 
         elif settings["lockscreen-locker"] == "gtklock":
             subprocess.call("pkill -f gtklock", shell=True)

--- a/nwg_shell_config/locker.py
+++ b/nwg_shell_config/locker.py
@@ -82,14 +82,10 @@ def set_remote_wallpaper():
         r = urllib.request.urlretrieve(url, wallpaper)
         if r[1]["Content-Type"] in ["image/jpeg", "image/png"]:
             if settings["lockscreen-locker"] == "swaylock":
-                subprocess.call("pkill -f swaylock", shell=True)
-                subprocess.Popen('swaylock -i {} ; kill -n 15 {}'.format(wallpaper, pid), shell=True)
+                subprocess.Popen('swaylock -i {}'.format(wallpaper), shell=True)
             elif settings["lockscreen-locker"] == "gtklock":
-                subprocess.call("pkill -f gtklock", shell=True)
-
-                eprint('{} -S -H -T 10 -b {} ; kill -n 15 {}'.format(gtklock_command(), wallpaper, pid))
-                subprocess.Popen('{} -S -H -T 10 -b {} ; kill -n 15 {}'.format(gtklock_command(), wallpaper, pid),
-                                 shell=True)
+                eprint('{} -S -H -T 10 -b {}'.format(gtklock_command(), wallpaper))
+                subprocess.Popen('{} -S -H -T 10 -b {}'.format(gtklock_command(), wallpaper), shell=True)
 
     except Exception as e:
         print(e)

--- a/nwg_shell_config/main_hyprland.py
+++ b/nwg_shell_config/main_hyprland.py
@@ -5,7 +5,7 @@ nwg-shell config utility
 Repository: https://github.com/nwg-piotr/nwg-shell-config
 Project site: https://nwg-piotr.github.io/nwg-shell
 Author's email: nwg.piotr@gmail.com
-Copyright (c) 2021-2023 Piotr Miller & Contributors
+Copyright (c) 2021-2024 Piotr Miller & Contributors
 License: MIT
 """
 
@@ -152,9 +152,10 @@ def side_menu():
     row.eb.connect("button-press-event", set_up_lockscreen_tab)
     list_box.add(row)
 
-    row = SideMenuRow(voc["gtklock"])
-    row.eb.connect("button-press-event", set_up_gtklock_tab)
-    list_box.add(row)
+    # currently gtklock does not work on Hyprland
+    # row = SideMenuRow(voc["gtklock"])
+    # row.eb.connect("button-press-event", set_up_gtklock_tab)
+    # list_box.add(row)
 
     row = SideMenuRow(voc["applications"])
     row.eb.connect("button-press-event", set_up_applications_tab)
@@ -1060,9 +1061,9 @@ def load_settings():
         "lockscreen-background-source": "local",  # unsplash | local
         "lockscreen-custom-cmd": "",
         "lockscreen-timeout": 1200,
-        "sleep-cmd": 'swaymsg "output * dpms off"',
+        "sleep-cmd": "systemctl suspend",
         "sleep-timeout": 1800,
-        "resume-cmd": 'swaymsg "output * dpms on"',
+        "resume-cmd": "",
         "before-sleep": "",
         "backgrounds-custom-path": "",
         "backgrounds-use-custom-path": False,

--- a/nwg_shell_config/ui_components.py
+++ b/nwg_shell_config/ui_components.py
@@ -1994,7 +1994,8 @@ def lockscreen_tab(settings, voc):
 
     combo_locker = Gtk.ComboBoxText()
     combo_locker.set_tooltip_text(voc["locker-tooltip"])
-    combo_locker.append("gtklock", "gtklock")
+    if not os.getenv("HYPRLAND_INSTANCE_SIGNATURE"):
+        combo_locker.append("gtklock", "gtklock")
     if is_command("swaylock"):
         combo_locker.append("swaylock", "swaylock")
     else:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-shell-config',
-    version='0.5.29',
+    version='0.5.30',
     description='nwg-shell configuration utility',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- closes #68 ;
- also gtklock has been removed from Hyprland-related settings, as it no longer works on Hyprland.