### PR TITLE
Support `-pbuseicontheme` drawer flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ for path in $PATTERN; do
 done
 
 # Remove launcher scripts
-filenames=("/usr/bin/$PROGRAM_NAME" "/usr/bin/nwg-autotranslate" "/usr/bin/nwg-shell-config" "/usr/bin/nwg-shell-config-sway" "/usr/bin/nwg-shell-config-hyprland" "/usr/bin/nwg-lock" "/usr/bin/nwg-shell-help" "/usr/bin/nwg-autotiling" "/usr/bin/nwg-shell-updater" "/usr/bin/nwg-shell-translate" "/usr/bin/nwg-update-indicator" "/usr/bin/nwg-screenshot-applet" "/usr/bin/nwg-dialog")
+filenames=("/usr/bin/nwg-autotranslate" "/usr/bin/nwg-shell-config" "/usr/bin/nwg-shell-config-sway" "/usr/bin/nwg-shell-config-hyprland" "/usr/bin/nwg-lock" "/usr/bin/nwg-shell-help" "/usr/bin/nwg-autotiling" "/usr/bin/nwg-shell-updater" "/usr/bin/nwg-shell-translate" "/usr/bin/nwg-update-indicator" "/usr/bin/nwg-screenshot-applet" "/usr/bin/nwg-dialog")
 for filename in "${filenames[@]}"; do
   if [ -f filename ]; then
     echo "Removing $filename"

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ done
 # Remove launcher scripts
 filenames=("/usr/bin/nwg-autotranslate" "/usr/bin/nwg-shell-config" "/usr/bin/nwg-shell-config-sway" "/usr/bin/nwg-shell-config-hyprland" "/usr/bin/nwg-lock" "/usr/bin/nwg-shell-help" "/usr/bin/nwg-autotiling" "/usr/bin/nwg-shell-updater" "/usr/bin/nwg-shell-translate" "/usr/bin/nwg-update-indicator" "/usr/bin/nwg-screenshot-applet" "/usr/bin/nwg-dialog")
 for filename in "${filenames[@]}"; do
-  if [ -f filename ]; then
+  if [ -f "$filename" ]; then
     echo "Removing $filename"
     rm filename
   fi

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,9 @@ for filename in "${filenames[@]}"; do
   echo "Removing -f $filename"
 done
 
+echo "Building"
 python -m build --wheel --no-isolation
+echo "Installing"
 python -m installer dist/*.whl
 
 install -Dm 644 -t "/usr/share/applications" "$PROGRAM_NAME.desktop"

--- a/install.sh
+++ b/install.sh
@@ -19,10 +19,8 @@ done
 # Remove launcher scripts
 filenames=("/usr/bin/nwg-autotranslate" "/usr/bin/nwg-shell-config" "/usr/bin/nwg-shell-config-sway" "/usr/bin/nwg-shell-config-hyprland" "/usr/bin/nwg-lock" "/usr/bin/nwg-shell-help" "/usr/bin/nwg-autotiling" "/usr/bin/nwg-shell-updater" "/usr/bin/nwg-shell-translate" "/usr/bin/nwg-update-indicator" "/usr/bin/nwg-screenshot-applet" "/usr/bin/nwg-dialog")
 for filename in "${filenames[@]}"; do
-  if [ -f "$filename" ]; then
-    echo "Removing $filename"
-    rm filename
-  fi
+  rm -f "$filename"
+  echo "Removing $filename"
 done
 
 python -m build --wheel --no-isolation

--- a/install.sh
+++ b/install.sh
@@ -16,11 +16,14 @@ for path in $PATTERN; do
     fi
 done
 
-# Remove launcher script
-if [ -f "/usr/bin/$PROGRAM_NAME" ]; then
-  echo "Removing /usr/bin/$PROGRAM_NAME"
-  rm "/usr/bin/$PROGRAM_NAME"
-fi
+# Remove launcher scripts
+filenames=("/usr/bin/$PROGRAM_NAME" "/usr/bin/nwg-autotranslate" "/usr/bin/nwg-shell-config" "/usr/bin/nwg-shell-config-sway" "/usr/bin/nwg-shell-config-hyprland" "/usr/bin/nwg-lock" "/usr/bin/nwg-shell-help" "/usr/bin/nwg-autotiling" "/usr/bin/nwg-shell-updater" "/usr/bin/nwg-shell-translate" "/usr/bin/nwg-update-indicator" "/usr/bin/nwg-screenshot-applet" "/usr/bin/nwg-dialog")
+for filename in "${filenames[@]}"; do
+  if [ -f filename ]; then
+    echo "Removing $filename"
+    rm filename
+  fi
+done
 
 python -m build --wheel --no-isolation
 python -m installer dist/*.whl

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ PATTERN="$SITE_PACKAGES/$MODULE_NAME*"
 # Remove from site_packages
 for path in $PATTERN; do
     if [ -e "$path" ]; then
-        echo "Removing -f $path"
+        echo "Removing $path"
         rm -r "$path"
     fi
 done
@@ -32,7 +32,7 @@ filenames=("/usr/bin/nwg-autotranslate"
 
 for filename in "${filenames[@]}"; do
   rm -f "$filename"
-  echo "Removing $filename"
+  echo "Removing -f $filename"
 done
 
 python -m build --wheel --no-isolation

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ done
 
 echo "Building"
 python -m build --wheel --no-isolation
-echo "Installing"
+
 python -m installer dist/*.whl
 
 install -Dm 644 -t "/usr/share/applications" "$PROGRAM_NAME.desktop"

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,42 @@
 #!/usr/bin/env bash
 
-python3 setup.py install --optimize=1
-cp nwg-shell-config.desktop /usr/share/applications/
-cp nwg-shell-config.svg /usr/share/pixmaps/
-cp nwg-shell-update.svg /usr/share/pixmaps/
-cp nwg-shell-translate.svg /usr/share/pixmaps/
-cp nwg-update-noupdate.svg /usr/share/pixmaps/
-cp nwg-update-available.svg /usr/share/pixmaps/
-cp nwg-update-checking.svg /usr/share/pixmaps/
-cp nwg-screenshot.svg /usr/share/pixmaps/
-cp nwg-3.svg /usr/share/pixmaps/
-cp nwg-2.svg /usr/share/pixmaps/
-cp nwg-1.svg /usr/share/pixmaps/
-cp nwg-system-update /usr/local/bin/
+# Before running this script, make sure you have python-build, python-installer,
+# python-wheel and python-setuptools installed.
+
+PROGRAM_NAME="nwg-shell-config"
+MODULE_NAME="nwg_shell_config"
+SITE_PACKAGES="$(python3 -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")"
+PATTERN="$SITE_PACKAGES/$MODULE_NAME*"
+
+# Remove from site_packages
+for path in $PATTERN; do
+    if [ -e "$path" ]; then
+        echo "Removing $path"
+        rm -r "$path"
+    fi
+done
+
+# Remove launcher script
+if [ -f "/usr/bin/$PROGRAM_NAME" ]; then
+  echo "Removing /usr/bin/$PROGRAM_NAME"
+  rm "/usr/bin/$PROGRAM_NAME"
+fi
+
+python -m build --wheel --no-isolation
+python -m installer dist/*.whl
+
+install -Dm 644 -t "/usr/share/applications" "$PROGRAM_NAME.desktop"
+install -Dm 644 -t "/usr/share/pixmaps" "$PROGRAM_NAME.svg"
+install -Dm 644 -t "/usr/share/pixmaps" nwg-shell-update.svg
+install -Dm 644 -t "/usr/share/pixmaps" nwg-shell-translate.svg
+install -Dm 644 -t "/usr/share/pixmaps" nwg-update-noupdate.svg
+install -Dm 644 -t "/usr/share/pixmaps" nwg-update-available.svg
+install -Dm 644 -t "/usr/share/pixmaps" nwg-update-checking.svg
+install -Dm 644 -t "/usr/share/pixmaps" nwg-screenshot.svg
+install -Dm 644 -t "/usr/share/pixmaps" nwg-3.svg
+install -Dm 644 -t "/usr/share/pixmaps" nwg-2.svg
+install -Dm 644 -t "/usr/share/pixmaps" nwg-1.svg
+install -Dm 755 -t "/usr/local/bin" nwg-system-update
 
 install -Dm 644 -t "/usr/share/licenses/nwg-shell-config" LICENSE
 install -Dm 644 -t "/usr/share/doc/nwg-shell-config" README.md

--- a/install.sh
+++ b/install.sh
@@ -11,13 +11,25 @@ PATTERN="$SITE_PACKAGES/$MODULE_NAME*"
 # Remove from site_packages
 for path in $PATTERN; do
     if [ -e "$path" ]; then
-        echo "Removing $path"
+        echo "Removing -f $path"
         rm -r "$path"
     fi
 done
 
 # Remove launcher scripts
-filenames=("/usr/bin/nwg-autotranslate" "/usr/bin/nwg-shell-config" "/usr/bin/nwg-shell-config-sway" "/usr/bin/nwg-shell-config-hyprland" "/usr/bin/nwg-lock" "/usr/bin/nwg-shell-help" "/usr/bin/nwg-autotiling" "/usr/bin/nwg-shell-updater" "/usr/bin/nwg-shell-translate" "/usr/bin/nwg-update-indicator" "/usr/bin/nwg-screenshot-applet" "/usr/bin/nwg-dialog")
+filenames=("/usr/bin/nwg-autotranslate"
+           "/usr/bin/nwg-shell-config"
+           "/usr/bin/nwg-shell-config-sway"
+           "/usr/bin/nwg-shell-config-hyprland"
+           "/usr/bin/nwg-lock"
+           "/usr/bin/nwg-shell-help"
+           "/usr/bin/nwg-autotiling"
+           "/usr/bin/nwg-shell-updater"
+           "/usr/bin/nwg-shell-translate"
+           "/usr/bin/nwg-update-indicator"
+           "/usr/bin/nwg-screenshot-applet"
+           "/usr/bin/nwg-dialog")
+
 for filename in "${filenames[@]}"; do
   rm -f "$filename"
   echo "Removing $filename"

--- a/nwg_shell_config/langs/en_US.json
+++ b/nwg_shell_config/langs/en_US.json
@@ -405,6 +405,8 @@
   "updates-page": "Updates page",
   "use-active-for-splits": "Use active for splits",
   "use-active-for-splits-tooltip": "Whether to prefer the active window or the mouse position for splits.",
+  "use-icon-theme": "Use icon theme in power bar",
+  "use-icon-theme-tooltip": "Use icon theme icons instead of built in",
   "use-these-settings": "Use these settings",
   "userinfo-module": "Userinfo module",
   "userinfo-tooltip": "For this module to work, you need to set the user info first. \nYou may use the `mugshot` or `SwaySettings` package. \nYou also need the `gtklock-userinfo-module` package.",

--- a/nwg_shell_config/langs/pl_PL.json
+++ b/nwg_shell_config/langs/pl_PL.json
@@ -405,6 +405,8 @@
   "updates-page": "Strona aktualizacji",
   "use-active-for-splits": "Użyj aktywnego do podziału",
   "use-active-for-splits-tooltip": "Określa czy przy podziale preferować aktywne okno, czy pozycję myszy.",
+  "use-icon-theme": "Używaj tematu ikon w pasku zasilania",
+  "use-icon-theme-tooltip": "Używaj ikon z GTK icon theme zamiast wbudowanych",
   "use-these-settings": "Używaj tych ustawień",
   "userinfo-module": "Moduł userinfo",
   "userinfo-tooltip": "Ten moduł potrzebuje informacji o użytkowniku.\nMożesz użyć pakietu `mugshot` lub `SwaySettings`. \nMusisz też zainstalować pakiet `gtklock-userinfo-module`.",

--- a/nwg_shell_config/main_hyprland.py
+++ b/nwg_shell_config/main_hyprland.py
@@ -645,6 +645,8 @@ def save_includes():
             cmd_launcher += f' -pbsleep \'{settings["pb-sleep"]}\''
         if preset["pb-size"] >= 8:
             cmd_launcher += f' -pbsize {preset["pb-size"]}'
+        if preset["pb-icon-theme"]:
+            cmd_launcher += ' -pbuseicontheme'
 
     if preset["launcher-on"]:
         if preset["launcher-resident"]:
@@ -1203,6 +1205,7 @@ def load_preset(file_name):
         "gtklock-playerctl-position": "top-right",
         "gtklock-playerctl-show-hidden": True,
         "powerbar-on": True,
+        "pb-icon-theme": False,
         "pb-size": 48
     }
     preset_file = os.path.join(data_dir, file_name)

--- a/nwg_shell_config/main_sway.py
+++ b/nwg_shell_config/main_sway.py
@@ -619,6 +619,8 @@ def save_includes():
             cmd_launcher += f' -pbsleep \'{settings["pb-sleep"]}\''
         if preset["pb-size"] >= 8:
             cmd_launcher += f' -pbsize {preset["pb-size"]}'
+        if preset["pb-icon-theme"]:
+            cmd_launcher += ' -pbuseicontheme'
 
     if preset["launcher-on"]:
         if preset["launcher-resident"]:
@@ -1050,6 +1052,7 @@ def load_preset(file_name):
         "gtklock-playerctl-position": "top-right",
         "gtklock-playerctl-show-hidden": True,
         "powerbar-on": True,
+        "pb-icon-theme": False,
         "pb-size": 48
     }
     preset_file = os.path.join(data_dir, file_name)

--- a/nwg_shell_config/ui_components.py
+++ b/nwg_shell_config/ui_components.py
@@ -2572,6 +2572,12 @@ def drawer_tab(preset, preset_name, outputs, voc):
     cb_show_power_bar.connect("toggled", set_from_checkbutton, preset, "powerbar-on")
     grid.attach(cb_show_power_bar, 2, 10, 2, 1)
 
+    cb_use_icon_theme = Gtk.CheckButton.new_with_label(voc["use-icon-theme"])
+    cb_use_icon_theme.set_tooltip_text(voc["use-icon-theme-tooltip"])
+    cb_use_icon_theme.set_active(preset["pb-icon-theme"])
+    cb_use_icon_theme.connect("toggled", set_from_checkbutton, preset, "pb-icon-theme")
+    grid.attach(cb_use_icon_theme, 2, 11, 2, 1)
+
     frame.show_all()
 
     return frame

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-shell-config',
-    version='0.5.41',
+    version='0.5.42',
     description='nwg-shell configuration utility',
     packages=find_packages(),
     include_package_data=True,

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,48 @@
 #!/usr/bin/env bash
 
-path=$(python -c 'import site; print(site.getsitepackages()[0])')
-rm -r $path'/nwg_shell_config*'
-rm /usr/bin/nwg-shell-config
-rm /usr/share/applications/nwg-shell-config.desktop
+PROGRAM_NAME="nwg-shell-config"
+MODULE_NAME="nwg_shell_config"
+SITE_PACKAGES="$(python3 -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")"
+PATTERN="$SITE_PACKAGES/$MODULE_NAME*"
+
+# Remove from site_packages
+for path in $PATTERN; do
+    if [ -e "$path" ]; then
+        echo "Removing $path"
+        rm -r "$path"
+    fi
+done
+
+# Remove launcher scripts
+filenames=("/usr/bin/nwg-autotranslate"
+           "/usr/bin/nwg-shell-config"
+           "/usr/bin/nwg-shell-config-sway"
+           "/usr/bin/nwg-shell-config-hyprland"
+           "/usr/bin/nwg-lock"
+           "/usr/bin/nwg-shell-help"
+           "/usr/bin/nwg-autotiling"
+           "/usr/bin/nwg-shell-updater"
+           "/usr/bin/nwg-shell-translate"
+           "/usr/bin/nwg-update-indicator"
+           "/usr/bin/nwg-screenshot-applet"
+           "/usr/bin/nwg-dialog")
+
+for filename in "${filenames[@]}"; do
+  rm -f "$filename"
+  echo "Removing -f $filename"
+done
+
+rm -f "/usr/share/applications $PROGRAM_NAME.desktop"
+rm -f "/usr/share/pixmaps $PROGRAM_NAME.svg"
+rm -f /usr/share/pixmaps/nwg-shell-update.svg
+rm -f /usr/share/pixmaps/nwg-shell-translate.svg
+rm -f /usr/share/pixmaps/nwg-update-noupdate.svg
+rm -f /usr/share/pixmaps/nwg-update-available.svg
+rm -f /usr/share/pixmaps/nwg-update-checking.svg
+rm -f /usr/share/pixmaps/nwg-screenshot.svg
+rm -f /usr/share/pixmaps/nwg-3.svg
+rm -f /usr/share/pixmaps/nwg-2.svg
+rm -f /usr/share/pixmaps/nwg-1.svg
+rm -f /usr/local/bin/nwg-system-update
+rm -f /usr/share/licenses/nwg-shell-config/LICENSE
+rm -f /usr/share/doc/nwg-shell-config/README.md


### PR DESCRIPTION
Added support for the `-pbuseicontheme` nwg-drawer flag. It forces use of GTK theme icons in power bar, instead of built-in icons (requested from Gentoo).

![obraz](https://github.com/nwg-piotr/nwg-shell-config/assets/20579136/90deb379-07a1-4d1f-b528-815f71b84dab)