### PR TITLE
fix f-string usage for Python 3.11 and earlier

### DIFF
--- a/nwg_shell_config/locker.py
+++ b/nwg_shell_config/locker.py
@@ -128,7 +128,7 @@ def load_wallhaven_image(path):
         image_url = image_data["data"][0]["path"]
 
         for key in image_data["data"][0]:
-            print(f"{key}: {image_data["data"][0][key]}")
+            print(f"{key}: {image_data['data'][0][key]}")
 
         # Download the image
         image_response = requests.get(image_url)


### PR DESCRIPTION
Nested double quotes in f-strings are only supported in Python 3.12 and later.

Downstream bug: https://bugs.gentoo.org/943225